### PR TITLE
Support drawio 13.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:latest
 
 WORKDIR /drawio
 
-ENV DRAWIO_VERSION "12.6.5"
+ENV DRAWIO_VERSION "13.7.3"
 RUN set -e; \
   apt-get update && apt-get install -y \
   libappindicator3-1 \
@@ -15,6 +15,7 @@ RUN set -e; \
   libsecret-1-0 \
   libxss1 \
   libxtst6 \
+  libgbm-dev \
   sgrep \
   wget \
   xdg-utils \

--- a/runner.sh
+++ b/runner.sh
@@ -18,10 +18,10 @@ suppress_autoupdate_warnings() {
 
 # shellcheck disable=SC2068
 if [ "${DRAWIO_CLI_SUPPRESS_WARNINGS:-false}" = true ]; then
-  "$DRAWIO_CLI" --no-sandbox $@ 2> >(suppress_deprecation_warnings) | suppress_autoupdate_warnings
+  "$DRAWIO_CLI" $@ --no-sandbox 2> >(suppress_deprecation_warnings) | suppress_autoupdate_warnings
 else
   # Currently drawio-desktop can hang inside a docker container
   # https://github.com/jgraph/drawio-desktop/issues/127
   echo "WARNING: This process can hang sometimes, don't hesitate to kill it."
-  "$DRAWIO_CLI" --no-sandbox $@
+  "$DRAWIO_CLI" $@ --no-sandbox
 fi


### PR DESCRIPTION
As discussed in #4 
This pull-requests bumps the drawio-version to 13.7.3 (latest according to https://github.com/jgraph/drawio-desktop/releases/tag/v13.7.3) and installes a required dependency.

Apparently the newer version of drawio requires some arguments to come last, without this last change electron simply quits with a 
```
Error: input file/directory not found
```